### PR TITLE
docs: added notion documentation link

### DIFF
--- a/docs/notion-link.md
+++ b/docs/notion-link.md
@@ -1,0 +1,3 @@
+## Notion Documentation
+
+The project documentation is available [here](https://www.notion.so/LyricFlip-Documentation-188644d19c538007af9be7fafb912b9c?pvs=4).


### PR DESCRIPTION
This PR fixes #95 

- The notion document follows the required structure.
- Links are functional and properly formatted.
- Icons and colors were applied.

<img width="1680" alt="Screenshot 2025-01-29 at 12 39 19 AM" src="https://github.com/user-attachments/assets/5ebab75e-b2a7-4b61-8f14-960d39d7b721" />
