### PR TITLE
added react query and zustand for remote and local state management

### DIFF
--- a/mobile-app/app/_layout.tsx
+++ b/mobile-app/app/_layout.tsx
@@ -1,12 +1,19 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
-import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
-import * as SplashScreen from 'expo-splash-screen';
-import { StatusBar } from 'expo-status-bar';
-import { useEffect } from 'react';
-import 'react-native-reanimated';
+import {
+  DarkTheme,
+  DefaultTheme,
+  ThemeProvider,
+} from "@react-navigation/native";
+import { useFonts } from "expo-font";
+import { Stack } from "expo-router";
+import * as SplashScreen from "expo-splash-screen";
+import { StatusBar } from "expo-status-bar";
+import { useEffect } from "react";
+import "react-native-reanimated";
 
-import { useColorScheme } from '@/hooks/useColorScheme';
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { queryClient } from "@/lib/queryClient";
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
@@ -14,7 +21,7 @@ SplashScreen.preventAutoHideAsync();
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const [loaded] = useFonts({
-    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
+    SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
 
   useEffect(() => {
@@ -28,16 +35,12 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-<<<<<<< HEAD
-      <Stack screenOptions={{headerShown: false}}>
-        <Stack.Screen name='index' options={{headerShown: false}} />
-=======
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="index" />
->>>>>>> 4b52bc85332eecc28d69d39ab2f4c88bc262745a
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="index" />
+        </Stack>
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 }

--- a/mobile-app/app/index.tsx
+++ b/mobile-app/app/index.tsx
@@ -1,25 +1,13 @@
-import { StyleSheet, Text, View } from 'react-native'
-import React from 'react'
-<<<<<<< HEAD
-import { Redirect, router } from 'expo-router'
-
-export default function () {
-  return (
-    // <View style={{margin: 50, backgroundColor: '#ccc', padding: 20}}>
-    //   <Text onPress={() => router.push("/(tabs)")}>TABS</Text>
-    // </View>
-
-    <Redirect href='/(drawer)/(tabs)' />
-=======
+import { StyleSheet, Text, View } from "react-native";
+import React from "react";
 import OnboardingScreen from "./screens/onboarding/onboarding.screen";
 
 export default function index() {
   return (
     <View>
- <OnboardingScreen />
+      <OnboardingScreen />
     </View>
->>>>>>> 4b52bc85332eecc28d69d39ab2f4c88bc262745a
-  )
+  );
 }
 
-const styles = StyleSheet.create({})
+const styles = StyleSheet.create({});

--- a/mobile-app/app/screens/onboarding/onboarding.screen.tsx
+++ b/mobile-app/app/screens/onboarding/onboarding.screen.tsx
@@ -1,12 +1,14 @@
-import { StyleSheet, Text, View } from 'react-native'
-import React from 'react'
+import { StyleSheet, Text, View } from "react-native";
+import React from "react";
+import TestSetup from "@/components/TestSetup";
 
 export default function onboardingScreen() {
   return (
     <View>
       <Text>onboardingScreen</Text>
+      <TestSetup />
     </View>
-  )
+  );
 }
 
-const styles = StyleSheet.create({})
+const styles = StyleSheet.create({});

--- a/mobile-app/components/TestSetup.tsx
+++ b/mobile-app/components/TestSetup.tsx
@@ -1,0 +1,34 @@
+import { View, Text, Button } from "react-native";
+import { useQuery } from "@tanstack/react-query";
+import { useAppStore } from "../store/store";
+
+// Simple test API call
+const fetchTest = async () => {
+  const response = await fetch("https://jsonplaceholder.typicode.com/todos/1");
+  return response.json();
+};
+
+export default function TestSetup() {
+  // Test Zustand
+  const { counter, increment, decrement } = useAppStore();
+
+  // Test React Query
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["test"],
+    queryFn: fetchTest,
+  });
+
+  return (
+    <View style={{ padding: 20 }}>
+      <Text>Zustand Test:</Text>
+      <Text>Counter: {counter}</Text>
+      <Button title="Increment" onPress={increment} />
+      <Button title="Decrement" onPress={decrement} />
+
+      <Text style={{ marginTop: 20 }}>React Query Test:</Text>
+      {isLoading && <Text>Loading...</Text>}
+      {error && <Text>Error: {(error as Error).message}</Text>}
+      {data && <Text>Data received: {JSON.stringify(data)}</Text>}
+    </View>
+  );
+}

--- a/mobile-app/lib/queryClient.ts
+++ b/mobile-app/lib/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60, // 1 minute
+      retry: 1,
+    },
+  },
+});

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -12,6 +12,9 @@
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/drawer": "^7.1.1",
         "@react-navigation/native": "^7.0.14",
+        "@tanstack/react-query": "^5.66.7",
+        "@tanstack/react-query-devtools": "^5.66.7",
+        "axios": "^1.7.9",
         "expo": "~52.0.33",
         "expo-blur": "~14.0.3",
         "expo-constants": "~17.0.5",
@@ -32,7 +35,8 @@
         "react-native-safe-area-context": "4.12.0",
         "react-native-screens": "~4.4.0",
         "react-native-web": "~0.19.13",
-        "react-native-webview": "13.12.5"
+        "react-native-webview": "13.12.5",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -4202,6 +4206,59 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.66.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.66.4.tgz",
+      "integrity": "sha512-skM/gzNX4shPkqmdTCSoHtJAPMTtmIJNS0hE+xwTTUVYwezArCT34NMermABmBVUg5Ls5aiUXEDXfqwR1oVkcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.65.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.65.0.tgz",
+      "integrity": "sha512-g5y7zc07U9D3esMdqUfTEVu9kMHoIaVBsD0+M3LPdAdD710RpTcLiNvJY1JkYXqkq9+NV+CQoemVNpQPBXVsJg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.66.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.66.7.tgz",
+      "integrity": "sha512-qd3q/tUpF2K1xItfPZddk1k/8pSXnovg41XyCqJgPoyYEirMBtB0sVEVVQ/CsAOngzgWtBPXimVf4q4kM9uO6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.66.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.66.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.66.7.tgz",
+      "integrity": "sha512-40z4PPkz06tYIF0vwLZZIZfZxKUH4OAaBOR14blCFyYm6hlU6qc+M82mkZ+D00HcEMhV7P4XeJiEuDhFq0q9Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.65.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.66.7",
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -4982,6 +5039,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-core": {
@@ -7532,6 +7615,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -11810,6 +11913,12 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -14929,6 +15038,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -19,6 +19,9 @@
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/drawer": "^7.1.1",
     "@react-navigation/native": "^7.0.14",
+    "@tanstack/react-query": "^5.66.7",
+    "@tanstack/react-query-devtools": "^5.66.7",
+    "axios": "^1.7.9",
     "expo": "~52.0.33",
     "expo-blur": "~14.0.3",
     "expo-constants": "~17.0.5",
@@ -39,7 +42,8 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5"
+    "react-native-webview": "13.12.5",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/mobile-app/store/store.ts
+++ b/mobile-app/store/store.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+
+interface AppState {
+  counter: number;
+  increment: () => void;
+  decrement: () => void;
+  // Add more state and actions as needed
+}
+
+export const useAppStore = create<AppState>((set) => ({
+  counter: 0,
+  increment: () => set((state) => ({ counter: state.counter + 1 })),
+  decrement: () => set((state) => ({ counter: state.counter - 1 })),
+}));


### PR DESCRIPTION
# React Query and Zustand Setup in React Native App

## Implementation Details
1. Set up React Query client configuration in `lib/queryClient.ts`
   - Configured with 1-minute stale time
   - Single retry attempt for failed queries

2. Integrated React Query Provider in `app/_layout.tsx`
   - Wrapped the app with QueryClientProvider
   - Removed web-only ReactQueryDevTools
   - Maintained existing theme and navigation setup

3. Created Zustand store in `store/store.ts`
   - Implemented a basic counter state
   - Added increment/decrement actions
   - Set up TypeScript interface for type safety

4. Created TestSetup component in `components/TestSetup.tsx`
   - Added counter UI with Zustand state management
   - Implemented test API call using React Query
   - Displays loading, error, and success states
   - Uses JSONPlaceholder API for testing

## Purpose
This setup provides a foundation for:
- Client-side state management with Zustand
- Server-state management with React Query
- Type-safe state management with TypeScript
- Testing capabilities for both state management solutions

## Testing
The implementation can be verified by:
- Using the counter buttons to test Zustand state
- Observing the API data fetch to test React Query
- Checking loading states and error handling