### PR TITLE
Feat: Add access control to LyricsFlipNFT contract minting

### DIFF
--- a/onchain/src/contracts/lyricsflip.cairo
+++ b/onchain/src/contracts/lyricsflip.cairo
@@ -4,7 +4,7 @@ pub mod LyricsFlip {
     use core::poseidon::PoseidonTrait;
     use lyricsflip::interfaces::lyricsflip::{ILyricsFlip};
     use lyricsflip::utils::errors::Errors;
-    use lyricsflip::utils::types::{Card, Entropy, Genre, Round, Answer};
+    use lyricsflip::utils::types::{Answer, Card, Entropy, Genre, Round};
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin_access::accesscontrol::{AccessControlComponent};
     use openzeppelin_access::ownable::OwnableComponent;
@@ -312,7 +312,7 @@ pub mod LyricsFlip {
         }
 
         fn set_role(
-            ref self: ContractState, recipient: ContractAddress, role: felt252, is_enable: bool
+            ref self: ContractState, recipient: ContractAddress, role: felt252, is_enable: bool,
         ) {
             self._set_role(recipient, role, is_enable);
         }
@@ -429,7 +429,7 @@ pub mod LyricsFlip {
         }
 
         fn _set_role(
-            ref self: ContractState, recipient: ContractAddress, role: felt252, is_enable: bool
+            ref self: ContractState, recipient: ContractAddress, role: felt252, is_enable: bool,
         ) {
             self.ownable.assert_only_owner();
             self.accesscontrol.assert_only_role(ADMIN_ROLE);

--- a/onchain/src/contracts/lyricsflipNFT.cairo
+++ b/onchain/src/contracts/lyricsflipNFT.cairo
@@ -72,6 +72,7 @@ mod LyricsFlipNFT {
         token_symbol: ByteArray,
         base_uri: ByteArray
     ) {
+        // Verify minter is a LyricsFlip contract by using a method defined on interface
         let lyrics_flip = ILyricsFlipDispatcher { contract_address: minter };
         match lyrics_flip.is_admin(selector!("ADMIN_ROLE"), owner) {
             true => (), // Contract exists and responds correctly

--- a/onchain/src/contracts/lyricsflipNFT.cairo
+++ b/onchain/src/contracts/lyricsflipNFT.cairo
@@ -7,9 +7,11 @@ pub trait ILyricsFlipNFT<TContractState> {
 
 #[starknet::contract]
 mod LyricsFlipNFT {
+    use lyricsflip::interfaces::lyricsflip::{ILyricsFlipDispatcher, ILyricsFlipDispatcherTrait};
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
+    use openzeppelin_access::accesscontrol::AccessControlComponent;
     use starknet::storage::StoragePointerReadAccess;
     use starknet::storage::StoragePointerWriteAccess;
     use starknet::{ContractAddress};
@@ -17,16 +19,23 @@ mod LyricsFlipNFT {
     component!(path: ERC721Component, storage: erc721, event: ERC721Event);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);
+
+    const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
 
     // External
     #[abi(embed_v0)]
     impl ERC721MixinImpl = ERC721Component::ERC721MixinImpl<ContractState>;
     #[abi(embed_v0)]
     impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl AccessControlImpl =
+        AccessControlComponent::AccessControlImpl<ContractState>;
 
     // Internal
     impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
     impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
 
     #[storage]
     struct Storage {
@@ -36,6 +45,8 @@ mod LyricsFlipNFT {
         src5: SRC5Component::Storage,
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        accesscontrol: AccessControlComponent::Storage,
         token_count: u256,
     }
 
@@ -48,25 +59,36 @@ mod LyricsFlipNFT {
         SRC5Event: SRC5Component::Event,
         #[flat]
         OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        AccessControlEvent: AccessControlComponent::Event,
     }
 
     #[constructor]
     fn constructor(
         ref self: ContractState,
         owner: ContractAddress,
+        minter: ContractAddress,
         token_name: ByteArray,
         token_symbol: ByteArray,
         base_uri: ByteArray
     ) {
+        let lyrics_flip = ILyricsFlipDispatcher { contract_address: minter };
+        match lyrics_flip.is_admin(selector!("ADMIN_ROLE"), owner) {
+            true => (), // Contract exists and responds correctly
+            false => (), // Contract exists but owner is not admin, which is fine
+        };
+
         self.erc721.initializer(token_name, token_symbol, base_uri);
         self.ownable.initializer(owner);
+        self.accesscontrol.initializer();
+        self.accesscontrol._grant_role(MINTER_ROLE, minter);
     }
 
     #[abi(embed_v0)]
     impl ILyricsFlipNFTImpl of super::ILyricsFlipNFT<ContractState> {
         fn mint(ref self: ContractState, recipient: ContractAddress) {
+            self.accesscontrol.assert_only_role(MINTER_ROLE);
             let mut token_id = self.token_count.read() + 1;
-            self.ownable.assert_only_owner();
             assert(!self.erc721.exists(token_id), 'NFT with id already exists');
             self.erc721.mint(recipient, token_id);
             self.token_count.write(token_id);

--- a/onchain/src/interfaces/lyricsflip.cairo
+++ b/onchain/src/interfaces/lyricsflip.cairo
@@ -1,4 +1,4 @@
-use lyricsflip::utils::types::{Card, Genre, Round, Answer};
+use lyricsflip::utils::types::{Answer, Card, Genre, Round};
 use starknet::ContractAddress;
 
 #[starknet::interface]
@@ -22,7 +22,7 @@ pub trait ILyricsFlip<TContractState> {
     fn set_cards_per_round(ref self: TContractState, value: u8);
     fn add_card(ref self: TContractState, card: Card);
     fn set_role(
-        ref self: TContractState, recipient: ContractAddress, role: felt252, is_enable: bool
+        ref self: TContractState, recipient: ContractAddress, role: felt252, is_enable: bool,
     );
 
     //TODO

--- a/onchain/src/tests/test_lyricsflip.cairo
+++ b/onchain/src/tests/test_lyricsflip.cairo
@@ -146,7 +146,6 @@ fn test_set_role_should_panic_when_called_by_non_owner() {
     stop_cheat_caller_address(lyricsflip.contract_address);
 }
 
-
 #[test]
 fn test_start_round() {
     let lyricsflip = deploy();
@@ -706,7 +705,6 @@ fn test_get_cards_of_artist_should_panic_with_zero_cards() {
             assert(*artist_cards.at(i).artist == 'Tupac', 'wrong artist');
         }
 }
-
 
 #[test]
 fn test_get_cards_of_a_year() {

--- a/onchain/src/tests/test_lyricsflip.cairo
+++ b/onchain/src/tests/test_lyricsflip.cairo
@@ -111,7 +111,7 @@ fn test_create_round() {
 #[test]
 fn test_set_role() {
     let lyricsflip = deploy();
-    let mut spy = spy_events();
+    let mut _spy = spy_events();
 
     start_cheat_caller_address(lyricsflip.contract_address, OWNER());
     lyricsflip.set_role(ADMIN_ADDRESS(), ADMIN_ROLE, true);
@@ -125,7 +125,7 @@ fn test_set_role() {
 #[should_panic(expected: "role not enable")]
 fn test_set_role_should_panic_when_invalid_role_is_passed() {
     let lyricsflip = deploy();
-    let mut spy = spy_events();
+    let mut _spy = spy_events();
 
     start_cheat_caller_address(lyricsflip.contract_address, OWNER());
     lyricsflip.set_role(ADMIN_ADDRESS(), INVALID_ROLE, true);

--- a/onchain/src/tests/test_lyricsflipNFT.cairo
+++ b/onchain/src/tests/test_lyricsflipNFT.cairo
@@ -54,8 +54,8 @@ fn setup_nft_dispatcher(lyrics_flip_address: ContractAddress) -> (ContractAddres
     nft_calldata.append(owner().into());
     nft_calldata.append(lyrics_flip_address.into());
 
-    let name: ByteArray = "TestNFT";
-    let symbol: ByteArray = "LYNFT";
+    let name: ByteArray = "LyricNFT";
+    let symbol: ByteArray = "LYFNFT";
     let base_uri: ByteArray = "baseuri";
 
     name.serialize(ref nft_calldata);
@@ -68,7 +68,7 @@ fn setup_nft_dispatcher(lyrics_flip_address: ContractAddress) -> (ContractAddres
 }
 
 #[test]
-#[should_panic()]
+#[should_panic]
 fn test_constructor_fails_with_invalid_minter() {
     let contract = declare("LyricsFlipNFT").unwrap().contract_class();
     let mut calldata: Array<felt252> = ArrayTrait::new();
@@ -200,7 +200,7 @@ fn test_mint_by_new_lyrics_flip_contract_should_fail() {
     // Deploy second LyricsFlip contract
     let second_lyrics_flip = deploy_lyrics_flip();
 
-    // Try to mint using the second LyricsFlip contract (should fail)
+    // Mint using the second LyricsFlip contract (should fail)
     start_cheat_caller_address(nft_address, second_lyrics_flip);
     dispatcher.mint(recipient());
     stop_cheat_caller_address(nft_address);

--- a/onchain/src/tests/test_lyricsflipNFT.cairo
+++ b/onchain/src/tests/test_lyricsflipNFT.cairo
@@ -6,30 +6,76 @@ use lyricsflip::contracts::lyricsflipNFT::{
     ILyricsFlipNFTDispatcher as NFTDispatcher, ILyricsFlipNFTDispatcherTrait as NFTDispatcherTrait
 };
 use openzeppelin::token::erc721::interface::{IERC721Dispatcher, IERC721DispatcherTrait};
+use openzeppelin_access::accesscontrol::interface::{
+    IAccessControlDispatcher, IAccessControlDispatcherTrait
+};
 use snforge_std::{
     declare, ContractClassTrait, DeclareResultTrait, start_cheat_caller_address,
     stop_cheat_caller_address
 };
-use starknet::{ContractAddress, contract_address_const};
+use starknet::ContractAddress;
+
+const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
 
 // Account functions
 fn owner() -> ContractAddress {
-    contract_address_const::<'OWNER'>()
+    'OWNER'.try_into().unwrap()
 }
 
-fn caller() -> ContractAddress {
-    contract_address_const::<'CALLER'>()
+fn lyrics_flip() -> ContractAddress {
+    'LYRICS_FLIP'.try_into().unwrap()
 }
 
-fn setup_dispatcher() -> (ContractAddress, NFTDispatcher) {
-    // Declare the contract
+fn non_minter() -> ContractAddress {
+    'NON_MINTER'.try_into().unwrap()
+}
+
+fn recipient() -> ContractAddress {
+    'RECIPIENT'.try_into().unwrap()
+}
+
+fn zero_address_const() -> ContractAddress {
+    '0x0'.try_into().unwrap()
+}
+
+fn deploy_lyrics_flip() -> ContractAddress {
+    let lyrics_flip_contract = declare("LyricsFlip").unwrap().contract_class();
+    let mut lyrics_flip_calldata = ArrayTrait::new();
+    lyrics_flip_calldata.append(owner().into()); // Owner for LyricsFlip contract
+    let (lyrics_flip_address, _) = lyrics_flip_contract.deploy(@lyrics_flip_calldata).unwrap();
+    lyrics_flip_address
+}
+
+fn setup_nft_dispatcher(lyrics_flip_address: ContractAddress) -> (ContractAddress, NFTDispatcher) {
+    let nft_contract = declare("LyricsFlipNFT").unwrap().contract_class();
+    let mut nft_calldata: Array<felt252> = ArrayTrait::new();
+
+    // Set owner and actual LyricsFlip contract address as minter
+    nft_calldata.append(owner().into());
+    nft_calldata.append(lyrics_flip_address.into());
+
+    let name: ByteArray = "TestNFT";
+    let symbol: ByteArray = "LYNFT";
+    let base_uri: ByteArray = "baseuri";
+
+    name.serialize(ref nft_calldata);
+    symbol.serialize(ref nft_calldata);
+    base_uri.serialize(ref nft_calldata);
+
+    let (nft_address, _) = nft_contract.deploy(@nft_calldata).unwrap();
+
+    (nft_address, NFTDispatcher { contract_address: nft_address })
+}
+
+#[test]
+#[should_panic()]
+fn test_constructor_fails_with_invalid_minter() {
     let contract = declare("LyricsFlipNFT").unwrap().contract_class();
-
-    // Prepare constructor calldata
     let mut calldata: Array<felt252> = ArrayTrait::new();
 
-    // Add constructor arguments
+    // Set owner and LyricsFlip contract address as minter
     calldata.append(owner().into());
+    calldata.append(non_minter().into()); // Not a LyricsFlip contract
 
     let name: ByteArray = "TestNFT";
     let symbol: ByteArray = "LYNFT";
@@ -39,34 +85,210 @@ fn setup_dispatcher() -> (ContractAddress, NFTDispatcher) {
     symbol.serialize(ref calldata);
     base_uri.serialize(ref calldata);
 
-    // Deploy contract
-    let (address, _) = contract.deploy(@calldata).unwrap();
-
-    // Create dispatcher
-    (address, NFTDispatcher { contract_address: address })
+    // This fail because non_minter() is not a LyricsFlip contract
+    let (_, _) = contract.deploy(@calldata).unwrap();
 }
 
 #[test]
-fn test_successful_mint() {
-    let (contract_address, dispatcher) = setup_dispatcher();
-    let recipient = contract_address_const::<'RECIPIENT'>();
+fn test_successful_mint_by_lyrics_flip() {
+    let lyrics_flip_address = deploy_lyrics_flip();
+    let (nft_address, dispatcher) = setup_nft_dispatcher(lyrics_flip_address);
 
-    start_cheat_caller_address(contract_address, owner());
-    dispatcher.mint(recipient);
-    stop_cheat_caller_address(contract_address);
+    // Mint using deployed LyricsFlip contract address
+    start_cheat_caller_address(nft_address, lyrics_flip_address);
+    dispatcher.mint(recipient());
+    stop_cheat_caller_address(nft_address);
 
-    let erc721 = IERC721Dispatcher { contract_address };
-    assert(erc721.owner_of(1) == recipient, 'Wrong owner');
-    assert(erc721.balance_of(recipient) == 1, 'Wrong balance');
+    let erc721 = IERC721Dispatcher { contract_address: nft_address };
+    assert(erc721.owner_of(1) == recipient(), 'Wrong owner');
+    assert(erc721.balance_of(recipient()) == 1, 'Wrong balance');
 }
 
 #[test]
-#[should_panic(expected: ('Caller is not the owner',))]
-fn test_mint_not_owner() {
-    let (contract_address, dispatcher) = setup_dispatcher();
-    let recipient = contract_address_const::<'RECIPIENT'>();
+#[should_panic(expected: ('Caller is missing role',))]
+fn test_mint_by_owner_should_fail() {
+    let lyrics_flip_address = deploy_lyrics_flip();
+    let (nft_address, dispatcher) = setup_nft_dispatcher(lyrics_flip_address);
 
-    start_cheat_caller_address(contract_address, caller());
-    dispatcher.mint(recipient);
-    stop_cheat_caller_address(contract_address);
+    // Try to mint as owner (should fail)
+    start_cheat_caller_address(nft_address, owner());
+    dispatcher.mint(recipient());
+    stop_cheat_caller_address(nft_address);
+}
+
+#[test]
+#[should_panic(expected: ('Caller is missing role',))]
+fn test_mint_by_non_minter_should_fail() {
+    let lyrics_flip_address = deploy_lyrics_flip();
+    let (nft_address, dispatcher) = setup_nft_dispatcher(lyrics_flip_address);
+
+    // Try to mint as random address (should fail)
+    start_cheat_caller_address(nft_address, non_minter());
+    dispatcher.mint(recipient());
+    stop_cheat_caller_address(nft_address);
+}
+
+#[test]
+fn test_minter_role_assignment() {
+    let lyrics_flip_address = deploy_lyrics_flip();
+    let (nft_address, _) = setup_nft_dispatcher(lyrics_flip_address);
+    let access_control = IAccessControlDispatcher { contract_address: nft_address };
+
+    // Verify LyricsFlip contract has minter role
+    assert(
+        access_control.has_role(MINTER_ROLE, lyrics_flip_address), 'LyricsFlip should be minter'
+    );
+
+    // Verify owner does not have minter role
+    assert(!access_control.has_role(MINTER_ROLE, owner()), 'Owner should not be minter');
+
+    // Verify random address does not have minter role
+    assert(!access_control.has_role(MINTER_ROLE, non_minter()), 'Non-minter should not have role');
+}
+
+#[test]
+fn test_sequential_minting() {
+    let lyrics_flip_address = deploy_lyrics_flip();
+    let (nft_address, dispatcher) = setup_nft_dispatcher(lyrics_flip_address);
+    let erc721 = IERC721Dispatcher { contract_address: nft_address };
+
+    start_cheat_caller_address(nft_address, lyrics_flip_address);
+
+    // Mint first token
+    dispatcher.mint(recipient());
+    assert(erc721.owner_of(1) == recipient(), 'Wrong owner of first token');
+
+    // Mint second token
+    dispatcher.mint(recipient());
+    assert(erc721.owner_of(2) == recipient(), 'Wrong owner of second token');
+
+    // Confirm correct recipient balance
+    assert(erc721.balance_of(recipient()) == 2, 'Wrong final balance');
+
+    stop_cheat_caller_address(nft_address);
+}
+
+#[test]
+fn test_mint_to_different_recipients() {
+    let lyrics_flip_address = deploy_lyrics_flip();
+    let (nft_address, dispatcher) = setup_nft_dispatcher(lyrics_flip_address);
+    let erc721 = IERC721Dispatcher { contract_address: nft_address };
+    let recipient2 = 'RECIPIENT2'.try_into().unwrap();
+
+    start_cheat_caller_address(nft_address, lyrics_flip_address);
+
+    // Mint to first recipient and check balance
+    dispatcher.mint(recipient());
+    assert(erc721.owner_of(1) == recipient(), 'Wrong owner of first token');
+    assert(erc721.balance_of(recipient()) == 1, 'Wrong balance for recipient1');
+
+    // Mint to second recipient and check balance
+    dispatcher.mint(recipient2);
+    assert(erc721.owner_of(2) == recipient2, 'Wrong owner of second token');
+    assert(erc721.balance_of(recipient2) == 1, 'Wrong balance for recipient2');
+
+    stop_cheat_caller_address(nft_address);
+}
+
+#[test]
+#[should_panic(expected: ('Caller is missing role',))]
+fn test_mint_by_new_lyrics_flip_contract_should_fail() {
+    // Deploy first LyricsFlip contract
+    let first_lyrics_flip = deploy_lyrics_flip();
+    let (nft_address, dispatcher) = setup_nft_dispatcher(first_lyrics_flip);
+
+    // Deploy second LyricsFlip contract
+    let second_lyrics_flip = deploy_lyrics_flip();
+
+    // Try to mint using the second LyricsFlip contract (should fail)
+    start_cheat_caller_address(nft_address, second_lyrics_flip);
+    dispatcher.mint(recipient());
+    stop_cheat_caller_address(nft_address);
+}
+
+#[test]
+fn test_mint_after_transfer() {
+    let lyrics_flip_address = deploy_lyrics_flip();
+    let (nft_address, dispatcher) = setup_nft_dispatcher(lyrics_flip_address);
+    let erc721 = IERC721Dispatcher { contract_address: nft_address };
+    let new_owner = 'NEWOWNER'.try_into().unwrap();
+
+    // Mint token
+    start_cheat_caller_address(nft_address, lyrics_flip_address);
+    dispatcher.mint(recipient());
+    stop_cheat_caller_address(nft_address);
+
+    // Transfer token
+    start_cheat_caller_address(nft_address, recipient());
+    erc721.transfer_from(recipient(), new_owner, 1);
+    stop_cheat_caller_address(nft_address);
+
+    // Verify transfer
+    assert(erc721.owner_of(1) == new_owner, 'Wrong owner after transfer');
+    assert(erc721.balance_of(new_owner) == 1, 'Wrong balance after transfer');
+    assert(erc721.balance_of(recipient()) == 0, 'Old owner should have 0');
+
+    // Verify can still mint after transfer
+    start_cheat_caller_address(nft_address, lyrics_flip_address);
+    dispatcher.mint(recipient());
+    stop_cheat_caller_address(nft_address);
+
+    assert(erc721.owner_of(2) == recipient(), 'Wrong owner of new token');
+}
+
+#[test]
+fn test_mint_to_zero_address_should_fail() {
+    let lyrics_flip_address = deploy_lyrics_flip();
+    let (nft_address, dispatcher) = setup_nft_dispatcher(lyrics_flip_address);
+    let zero_address: ContractAddress = zero_address_const();
+
+    start_cheat_caller_address(nft_address, lyrics_flip_address);
+    dispatcher.mint(zero_address);
+    stop_cheat_caller_address(nft_address);
+}
+
+#[test]
+fn test_concurrent_minting() {
+    let lyrics_flip_address = deploy_lyrics_flip();
+    let (nft_address, dispatcher) = setup_nft_dispatcher(lyrics_flip_address);
+    let erc721 = IERC721Dispatcher { contract_address: nft_address };
+
+    // Simulate concurrent minting by rapidly minting multiple tokens
+    start_cheat_caller_address(nft_address, lyrics_flip_address);
+
+    let mut recipients = array![
+        'RECIPIENT3'.try_into().unwrap(),
+        'RECIPIENT4'.try_into().unwrap(),
+        'RECIPIENT5'.try_into().unwrap(),
+        'RECIPIENT6'.try_into().unwrap(),
+        'RECIPIENT7'.try_into().unwrap(),
+        'RECIPIENT8'.try_into().unwrap(),
+        'RECIPIENT9'.try_into().unwrap(),
+        'RECIPIENT10'.try_into().unwrap()
+    ];
+
+    // Mint tokens to different recipients rapidly
+    let mut i: u32 = 0;
+    loop {
+        if i >= recipients.len() {
+            break;
+        }
+        dispatcher.mint(*recipients.at(i.into()));
+        i += 1;
+    };
+
+    stop_cheat_caller_address(nft_address);
+
+    // Verify all tokens were minted correctly and sequentially
+    let mut j: u32 = 0;
+    loop {
+        if j >= recipients.len() {
+            break;
+        }
+        let token_id = j + 1;
+        let recipient = *recipients.at(j.into());
+        assert(erc721.owner_of(token_id.into()) == recipient, 'Wrong token owner');
+        assert(erc721.balance_of(recipient) == 1, 'Wrong recipient balance');
+        j += 1;
+    };
 }


### PR DESCRIPTION
# 🎶  LyricsFlip Pull Request


- [x] Closes #107 
- [x] Added tests
- [x] Run tests
- [x] Run formatting
- [x] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

- Added OpenZeppelin access control to the LyricsFlipNFT contract minting function to prevent minting from any origin that is not the LyricsFlip contract
- Added a robust unit testing suite to confirm mint from a specified origin and verify hitch-free mint to recipients 

---

## 📸 Evidence 

<img width="1118" alt="Screenshot 2025-02-22 at 20 30 25" src="https://github.com/user-attachments/assets/191b5583-3f42-48ef-9bc8-c8c36fca452e" />

- `scarb test`

<img width="1042" alt="Screenshot 2025-02-22 at 20 33 59" src="https://github.com/user-attachments/assets/a693c742-b277-40c7-89a1-3a48c2167a57" />

- `scarb build`

---

## 🌌 Comments

- Verify LyricsFlipNFT does not have a predetermined address and works with any deployed contract instance
